### PR TITLE
Fix lexer EOF check

### DIFF
--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -158,7 +158,7 @@ export class Lexer {
   }
 
   private isEOF(): boolean {
-    if (this.readPosition >= this.source.length) return true;
+    return this.readPosition >= this.source.length;
   }
 
   private peekCharacter(): string {


### PR DESCRIPTION
## Summary
- ensure the lexer `isEOF` method always returns a boolean

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe9573b04832ba94d31e08ab10111