### PR TITLE
Add parser index expression test

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -58,6 +58,7 @@ const precedences: { [K in TokenType]?: Precedence } = {
   [TokenType.DO]: Precedence.CALL,
   [TokenType.WHILE]: Precedence.CALL,
   [TokenType.FOR]: Precedence.CALL,
+  [TokenType.LBRACKET]: Precedence.CALL,
   [TokenType.LPAREN]: Precedence.CALL,
 };
 
@@ -232,7 +233,6 @@ export class Parser {
     this.assertPeekToken();
     while (this.peekToken.type !== TokenType.SEMICOLON && precedence < this.peekPrecedence()) {
       const infixParseFn = this.infixParseFns[this.peekToken.type];
-      console.log(`${this.peekToken.type} => ${infixParseFn}`);
       if (infixParseFn === undefined) {
         return leftExpression;
       }
@@ -384,8 +384,10 @@ export class Parser {
 
   private parseExpressionStatement(): ExpressionStatement | null {
     this.assertCurrentToken();
-    const expressionStatement = new ExpressionStatement(this.currentToken, this.parseExpression(Precedence.LOWEST));
-    console.log(expressionStatement);
+    const expressionStatement = new ExpressionStatement(
+      this.currentToken,
+      this.parseExpression(Precedence.LOWEST),
+    );
 
     this.assertPeekToken();
 

--- a/src/tests/parser.spec.ts
+++ b/src/tests/parser.spec.ts
@@ -20,6 +20,7 @@ import {
   For,
   StringLiteral,
   ArrayLiteral,
+  Index,
 } from '../ast';
 
 function printProgram(program: Program) {
@@ -622,5 +623,21 @@ describe('parse', () => {
     const arrayLiteral = expressionStatement.expression as ArrayLiteral;
     expect(arrayLiteral).toBeInstanceOf(ArrayLiteral);
     expect(arrayLiteral.elements.length).toBe(3);
+  });
+
+  it('should parse a program with index expression', () => {
+    const source = `ident[1 + 1];`;
+    const lexer = new Lexer(source);
+    const parse = new Parser(lexer);
+    const program = parse.parseProgram();
+
+    testProgramStatement(parse, program, 1);
+
+    const expressionStatement = program.statements[0] as ExpressionStatement;
+    const indexExpression = expressionStatement.expression as Index;
+
+    expect(indexExpression).toBeInstanceOf(Index);
+    testIdentifier(indexExpression.left, 'ident');
+    testInfix(indexExpression.index, 1, '+', 1);
   });
 });


### PR DESCRIPTION
## Summary
- test parsing of index expressions
- support index expressions by increasing precedence for '[' and removing debug logs

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686fea755eec832bb507e9da0f433673