### PR TITLE
Fix infix operator errors

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -237,9 +237,9 @@ const evaluateInfixExpression = (
       column,
     });
   } else {
-    return newError('UNKNOWN_OPERATOR', {
-      operator: nodeOperator,
+    return newError('UNKNOWN_INFIX_OPERATOR', {
       left: left.type(),
+      operator: nodeOperator,
       right: right.type(),
       line,
       column,
@@ -277,9 +277,9 @@ const evaluateNumberInfixExpression = (
       return toBooleanObject(left.value >= right.value);
     default:
       return newError('UNKNOWN_INFIX_OPERATOR', {
-        type1: left.type(),
+        left: left.type(),
         operator: nodeOperator,
-        type2: right.type(),
+        right: right.type(),
         line,
         column,
       });


### PR DESCRIPTION
## Summary
- update default case in `evaluateInfixExpression` to use `UNKNOWN_INFIX_OPERATOR`
- fix error object keys in `evaluateNumberInfixExpression`

## Testing
- `npx vitest run` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_686fea73783c832b9b0ff08d21bd6d7c