### PR TITLE
Fix typo in inspector comment

### DIFF
--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -1,7 +1,7 @@
 import { Program } from './ast';
 
 /**
- * function para reprecentar el AST de un programa en un arbol como este:
+ * function para representar el AST de un programa en un arbol como este:
  *  Program
  *  |- Statements
  *  | |- variable orden =


### PR DESCRIPTION
## Summary
- correct a typo in inspector comment

## Testing
- `npx vitest run` *(fails: 403 Forbidden due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_686fea71b04c832b85c75e572e086694