### PR TITLE
feat: expose AST API and runtime tracing engine

### DIFF
--- a/src/astSerializer.ts
+++ b/src/astSerializer.ts
@@ -1,0 +1,238 @@
+import * as ast from './ast';
+
+export interface SerializedASTChild {
+  relation: string;
+  node: SerializedASTNode;
+}
+
+export interface SerializedASTNode {
+  id: string;
+  type: string;
+  position: { line: number; column: number };
+  tokenLiteral: string;
+  metadata: Record<string, unknown>;
+  parentId: string | null;
+  children: SerializedASTChild[];
+}
+
+export interface SerializerOptions {
+  includeEmptyChildren?: boolean;
+}
+
+export const serializeProgram = (
+  program: ast.Program,
+  options: SerializerOptions = {},
+): SerializedASTNode => {
+  const idGenerator = createIdGenerator();
+  return serializeNode(program, null, idGenerator, options);
+};
+
+export const serializeNode = (
+  node: ast.ASTNode,
+  parentId: string | null,
+  idGenerator: () => string,
+  options: SerializerOptions = {},
+): SerializedASTNode => {
+  const id = idGenerator();
+  const base: SerializedASTNode = {
+    id,
+    type: node.constructor.name,
+    position: resolvePosition(node),
+    tokenLiteral: node.tokenLiteral(),
+    metadata: collectMetadata(node),
+    parentId,
+    children: [],
+  };
+
+  const children = collectChildren(node);
+  for (const child of children) {
+    if (!child.node) {
+      if (options.includeEmptyChildren) {
+        base.children.push({ relation: child.relation, node: createEmptyNode(idGenerator, id, child.relation) });
+      }
+      continue;
+    }
+    base.children.push({
+      relation: child.relation,
+      node: serializeNode(child.node, id, idGenerator, options),
+    });
+  }
+
+  return base;
+};
+
+const collectMetadata = (node: ast.ASTNode): Record<string, unknown> => {
+  const metadata: Record<string, unknown> = {};
+
+  if (node instanceof ast.Program) {
+    metadata.kind = 'Program';
+  } else if (node instanceof ast.Statement) {
+    metadata.kind = 'Statement';
+  } else if (node instanceof ast.Expression) {
+    metadata.kind = 'Expression';
+  }
+
+  if (node instanceof ast.LetStatement) {
+    metadata.identifier = node.name?.value ?? null;
+  }
+  if (node instanceof ast.ReturnStatement) {
+    metadata.hasValue = Boolean(node.returnValue);
+  }
+  if (node instanceof ast.Number) {
+    metadata.value = node.value;
+  }
+  if (node instanceof ast.Boolean) {
+    metadata.value = node.value;
+  }
+  if (node instanceof ast.StringLiteral) {
+    metadata.value = node.value;
+  }
+  if (node instanceof ast.Identifier) {
+    metadata.name = node.value;
+  }
+  if (node instanceof ast.Prefix) {
+    metadata.operator = node.operator;
+  }
+  if (node instanceof ast.Infix) {
+    metadata.operator = node.operator;
+  }
+  if (node instanceof ast.Function) {
+    metadata.parameters = node.parameters?.map(parameter => parameter.value) ?? [];
+    metadata.isAnonymous = node.isAnonymous ?? false;
+    metadata.name = node.name?.value ?? null;
+  }
+  if (node instanceof ast.Call) {
+    metadata.arguments = node.arguments_?.length ?? 0;
+    metadata.calleeType = node.function_?.constructor?.name ?? 'Unknown';
+  }
+  if (node instanceof ast.Block) {
+    metadata.size = node.statements.length;
+  }
+  if (node instanceof ast.Program) {
+    metadata.size = node.statements.length;
+  }
+  if (node instanceof ast.ArrayLiteral) {
+    metadata.length = node.elements?.length ?? 0;
+  }
+
+  return metadata;
+};
+
+interface ChildRelation {
+  relation: string;
+  node?: ast.ASTNode;
+}
+
+const collectChildren = (node: ast.ASTNode): ChildRelation[] => {
+  if (node instanceof ast.Program) {
+    return node.statements.map(statement => ({ relation: 'statement', node: statement }));
+  }
+  if (node instanceof ast.LetStatement) {
+    return compact([
+      { relation: 'identifier', node: node.name },
+      { relation: 'value', node: node.value },
+    ]);
+  }
+  if (node instanceof ast.ReturnStatement) {
+    return compact([{ relation: 'value', node: node.returnValue }]);
+  }
+  if (node instanceof ast.ExpressionStatement) {
+    return compact([{ relation: 'expression', node: node.expression }]);
+  }
+  if (node instanceof ast.Prefix) {
+    return compact([{ relation: 'right', node: node.right }]);
+  }
+  if (node instanceof ast.Infix) {
+    return compact([
+      { relation: 'left', node: node.left },
+      { relation: 'right', node: node.right },
+    ]);
+  }
+  if (node instanceof ast.If) {
+    return compact([
+      { relation: 'condition', node: node.condition },
+      { relation: 'consequence', node: node.consequence },
+      { relation: 'alternative', node: node.alternative },
+    ]);
+  }
+  if (node instanceof ast.While) {
+    return compact([
+      { relation: 'condition', node: node.condition },
+      { relation: 'body', node: node.body },
+    ]);
+  }
+  if (node instanceof ast.DoWhile) {
+    return compact([
+      { relation: 'body', node: node.body },
+      { relation: 'condition', node: node.condition },
+    ]);
+  }
+  if (node instanceof ast.For) {
+    return compact([
+      { relation: 'initializer', node: node.initializer },
+      { relation: 'condition', node: node.condition },
+      { relation: 'increment', node: node.increment },
+      { relation: 'body', node: node.body },
+    ]);
+  }
+  if (node instanceof ast.Block) {
+    return node.statements.map(statement => ({ relation: 'statement', node: statement }));
+  }
+  if (node instanceof ast.Function) {
+    const parameterRelations = (node.parameters ?? []).map(parameter => ({ relation: 'parameter', node: parameter }));
+    return [...parameterRelations, ...compact([{ relation: 'body', node: node.body }])];
+  }
+  if (node instanceof ast.Call) {
+    const argumentRelations = (node.arguments_ ?? []).map(argument => ({ relation: 'argument', node: argument }));
+    return compact([{ relation: 'function', node: node.function_ }, ...argumentRelations]);
+  }
+  if (node instanceof ast.ArrayLiteral) {
+    return (node.elements ?? []).map(element => ({ relation: 'element', node: element }));
+  }
+  if (node instanceof ast.Index) {
+    return compact([
+      { relation: 'left', node: node.left },
+      { relation: 'index', node: node.index },
+    ]);
+  }
+  return [];
+};
+
+const compact = (relations: ChildRelation[]): ChildRelation[] => {
+  return relations.filter(relation => relation.node !== null && relation.node !== undefined);
+};
+
+const resolvePosition = (node: ast.ASTNode): { line: number; column: number } => {
+  if (node instanceof ast.Program && node.statements.length > 0) {
+    return { line: node.statements[0].line, column: node.statements[0].column };
+  }
+  if (node instanceof ast.Block && node.statements.length > 0) {
+    return { line: node.statements[0].line, column: node.statements[0].column };
+  }
+  return {
+    line: node.line ?? 0,
+    column: node.column ?? 0,
+  };
+};
+
+const createEmptyNode = (
+  idGenerator: () => string,
+  parentId: string,
+  relation: string,
+): SerializedASTNode => ({
+  id: idGenerator(),
+  type: 'Empty',
+  position: { line: 0, column: 0 },
+  tokenLiteral: relation,
+  metadata: {},
+  parentId,
+  children: [],
+});
+
+const createIdGenerator = (): (() => string) => {
+  let counter = 0;
+  return () => {
+    counter += 1;
+    return `node-${counter}`;
+  };
+};

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,0 +1,91 @@
+import { serializeProgram, SerializedASTNode, SerializerOptions } from './astSerializer';
+import * as ast from './ast';
+import { createEvaluator, EvaluationOptions } from './evaluator';
+import { Lexer } from './lexer';
+import { Environment, Object as RuntimeObject } from './object';
+import { Parser } from './parser';
+import { RuntimeTrace, RuntimeTracer } from './runtime/tracer';
+
+export interface ParseResult {
+  program: ast.Program | null;
+  errors: string[];
+}
+
+export interface ASTResult {
+  ast: SerializedASTNode | null;
+  errors: string[];
+  program: ast.Program | null;
+}
+
+export interface RunOptions extends EvaluationOptions {
+  trace?: boolean;
+  environment?: Environment;
+}
+
+export interface RunResult {
+  result: RuntimeObject | null;
+  errors: string[];
+  trace?: RuntimeTrace;
+  program: ast.Program | null;
+  environment: Environment;
+}
+
+export class CodexivoEngine {
+  parse(source: string): ParseResult {
+    const lexer = new Lexer(source);
+    const parser = new Parser(lexer);
+    const program = parser.parseProgram();
+    return {
+      program,
+      errors: [...parser.errors],
+    };
+  }
+
+  getAST(source: string, options: SerializerOptions = {}): ASTResult {
+    const { program, errors } = this.parse(source);
+    if (errors.length > 0 || !program) {
+      return { ast: null, errors, program };
+    }
+    return {
+      ast: serializeProgram(program, options),
+      errors: [],
+      program,
+    };
+  }
+
+  run(source: string, options: RunOptions = {}): RunResult {
+    const { program, errors } = this.parse(source);
+    if (errors.length > 0 || !program) {
+      return {
+        result: null,
+        errors,
+        program,
+        trace: undefined,
+        environment: options.environment ?? new Environment(),
+      };
+    }
+
+    const {
+      trace,
+      tracer: providedTracer,
+      environment: providedEnvironment,
+      ...evaluatorOptions
+    } = options;
+
+    const environment = providedEnvironment ?? new Environment();
+    const tracer = providedTracer ?? (trace ? new RuntimeTracer(evaluatorOptions) : undefined);
+    const evaluator = createEvaluator({ ...(evaluatorOptions as EvaluationOptions), tracer });
+    const result = evaluator.evaluate(program, environment, program.line, program.column);
+    return {
+      result,
+      errors: [],
+      trace: tracer?.getTrace(),
+      program,
+      environment,
+    };
+  }
+
+  createTracer(options: EvaluationOptions = {}): RuntimeTracer {
+    return options.tracer ?? new RuntimeTracer(options);
+  }
+}

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1,101 +1,299 @@
 import * as ast from './ast';
 import {
-  Number as NumberObj,
-  Object,
-  Boolean,
-  Null,
-  Return,
-  Error as ErrorObj,
-  Environment,
-  Function,
-  String,
+  Boolean as BooleanObj,
   Builtin,
+  Environment,
+  Error as ErrorObj,
+  Function as RuntimeFunction,
+  Null,
+  Number as NumberObj,
+  Object as RuntimeObject,
+  Return,
+  String as StringObj,
 } from './object';
 import { reservedKeywords } from './token';
 import { builtins } from './builtins';
 import { newError } from './errors';
+import { RuntimeTracer, RuntimeTracerOptions } from './runtime/tracer';
 
-const TRUE = new Boolean(true);
-const FALSE = new Boolean(false);
+const TRUE = new BooleanObj(true);
+const FALSE = new BooleanObj(false);
 const NULL = new Null();
 
-export const evaluate = (node: ast.ASTNode, env: Environment, line?: number, column?: number): Object => {
-  if (node instanceof ast.Program) {
-    assertValue(node.statements);
-    return evaluateProgram(node, env);
-  } else if (node instanceof ast.ExpressionStatement) {
-    assertValue(node.expression);
-    return evaluate(node.expression, env, node.line, node.column);
-  } else if (node instanceof ast.Number) {
-    assertValue(node.value);
-    assertNumber(node.value);
-    return new NumberObj(node.value);
-  } else if (node instanceof ast.Boolean) {
-    assertValue(node.value);
-    return toBooleanObject(node.value);
-  } else if (node instanceof ast.Prefix) {
-    assertValue(node.right);
-    const right = evaluate(node.right, env, node.line, node.column);
-    assertValue(right);
-    return evaluatePrefixExpression(node.operator, right, node.line ?? line, node.column ?? column);
-  } else if (node instanceof ast.Infix) {
-    assertValue(node.left);
-    assertValue(node.right);
-    const left = evaluate(node.left, env, node.line, node.column);
-    const right = evaluate(node.right, env, node.line, node.column);
-    assertValue(left);
-    assertValue(right);
-    return evaluateInfixExpression(node.operator, left, right, node.line ?? line, node.column ?? column);
-  } else if (node instanceof ast.Block) {
-    return evaluateBlockStatement(node, env, node.line, node.column);
-  } else if (node instanceof ast.If) {
-    return evaluateIfExpression(node, env);
-  } else if (node instanceof ast.ReturnStatement) {
-    assertValue(node.returnValue);
-    const value = evaluate(node.returnValue, env, node.line, node.column);
-    assertValue(value);
-    return new Return(value);
-  } else if (node instanceof ast.LetStatement) {
-    assertValue(node.value);
-    const value = evaluate(node.value, env, node.line, node.column);
-    assertValue(node.name);
-    env.set(node.name.value, value);
-  } else if (node instanceof ast.Identifier) {
-    return evaluateIdentifier(node, env, node.line, node.column);
-  } else if (node instanceof ast.Function) {
-    assertValue(node.parameters);
-    assertValue(node.body);
-    return new Function(node.parameters, node.body, env);
-  } else if (node instanceof ast.Call) {
-    const functionObj = evaluate(node.function_, env, node.line, node.column);
-    const args = evaluateExpression(node.arguments_, env, node.line, node.column);
-    assertValue(args);
-    assertValue(functionObj);
-    return applyFunction(functionObj, args, node.line, node.column);
-  } else if (node instanceof ast.StringLiteral) {
-    assertValue(node.value);
-    return new String(node.value);
-  } else {
-    return NULL;
-  }
-};
+export interface EvaluationOptions extends RuntimeTracerOptions {
+  tracer?: RuntimeTracer;
+}
 
-const applyFunction = (fn: Object, args: Object[], line: number, column: number): Object => {
-  if (fn instanceof Function) {
-    const extendedEnv = extendFunctionEnv(fn, args);
-    const evaluated = evaluate(fn.body, extendedEnv);
-    assertValue(evaluated);
-    return unwrapReturnValue(evaluated);
-  } else if (fn instanceof Builtin) {
-    const result = fn.fn(...args);
-    if (result instanceof ErrorObj) {
-      return newError('GENERIC_ERROR', { message: result.message, line, column });
+interface EvaluationState {
+  tracer?: RuntimeTracer;
+}
+
+export interface Evaluator {
+  evaluate(node: ast.ASTNode, env: Environment, line?: number, column?: number): RuntimeObject;
+  tracer?: RuntimeTracer;
+}
+
+export const createEvaluator = (options: EvaluationOptions = {}): Evaluator => {
+  const tracer = options.tracer ?? (shouldInstantiateTracer(options) ? new RuntimeTracer(options) : undefined);
+  const state: EvaluationState = { tracer };
+
+  const record = (node: ast.ASTNode, env: Environment, result: RuntimeObject | undefined, operation: string) => {
+    state.tracer?.record({ node, env, result, operation });
+  };
+
+  const evaluateNode = (
+    node: ast.ASTNode,
+    env: Environment,
+    line: number = node.line ?? 0,
+    column: number = node.column ?? 0,
+  ): RuntimeObject => {
+    if (node instanceof ast.Program) {
+      state.tracer?.enterFrame({ name: 'programa', type: 'program', location: { line: node.line, column: node.column } });
+      let result: RuntimeObject = NULL;
+      for (const statement of node.statements) {
+        result = evaluateNode(statement, env, statement.line, statement.column);
+        if (result instanceof Return) {
+          const value = result.value;
+          record(node, env, value, 'program:return');
+          state.tracer?.exitFrame();
+          return value;
+        }
+        if (result instanceof ErrorObj) {
+          record(node, env, result, 'program:error');
+          state.tracer?.exitFrame();
+          return result;
+        }
+      }
+      record(node, env, result, 'program:evaluate');
+      state.tracer?.exitFrame();
+      return result;
+    }
+
+    if (node instanceof ast.ExpressionStatement) {
+      if (!node.expression) {
+        record(node, env, NULL, 'expression:empty');
+        return NULL;
+      }
+      const result = evaluateNode(node.expression, env, node.line, node.column);
+      record(node, env, result, 'expression:evaluate');
+      return result;
+    }
+
+    if (node instanceof ast.Number) {
+      assertValue(node.value);
+      assertNumber(node.value);
+      const result = new NumberObj(node.value);
+      record(node, env, result, 'literal:number');
+      return result;
+    }
+
+    if (node instanceof ast.Boolean) {
+      assertValue(node.value);
+      const result = toBooleanObject(node.value);
+      record(node, env, result, 'literal:boolean');
+      return result;
+    }
+
+    if (node instanceof ast.StringLiteral) {
+      assertValue(node.value);
+      const result = new StringObj(node.value);
+      record(node, env, result, 'literal:string');
+      return result;
+    }
+
+    if (node instanceof ast.Prefix) {
+      assertValue(node.operator);
+      assertValue(node.right);
+      const right = evaluateNode(node.right, env, node.line, node.column);
+      const result = evaluatePrefixExpression(node.operator, right, node.line ?? line, node.column ?? column);
+      record(node, env, result, 'expression:prefix');
+      return result;
+    }
+
+    if (node instanceof ast.Infix) {
+      assertValue(node.left);
+      assertValue(node.right);
+      const left = evaluateNode(node.left, env, node.line, node.column);
+      const right = evaluateNode(node.right, env, node.line, node.column);
+      const result = evaluateInfixExpression(node.operator, left, right, node.line ?? line, node.column ?? column);
+      record(node, env, result, 'expression:infix');
+      return result;
+    }
+
+    if (node instanceof ast.Block) {
+      const result = evaluateBlockStatement(node, env, node.line ?? line, node.column ?? column);
+      record(node, env, result, 'block:evaluate');
+      return result;
+    }
+
+    if (node instanceof ast.If) {
+      const result = evaluateIfExpression(node, env);
+      record(node, env, result, 'expression:if');
+      return result;
+    }
+
+    if (node instanceof ast.ReturnStatement) {
+      assertValue(node.returnValue);
+      const value = evaluateNode(node.returnValue, env, node.line, node.column);
+      const result = new Return(value);
+      record(node, env, value, 'statement:return');
+      return result;
+    }
+
+    if (node instanceof ast.LetStatement) {
+      assertValue(node.value);
+      assertValue(node.name);
+      const value = evaluateNode(node.value, env, node.line, node.column);
+      env.set(node.name.value, value);
+      record(node, env, value, 'statement:let');
+      return value;
+    }
+
+    if (node instanceof ast.Identifier) {
+      const result = evaluateIdentifier(node, env, node.line ?? line, node.column ?? column);
+      record(node, env, result, 'expression:identifier');
+      return result;
+    }
+
+    if (node instanceof ast.Function) {
+      assertValue(node.parameters);
+      assertValue(node.body);
+      const result = new RuntimeFunction(node.parameters, node.body, env, node.name?.value);
+      record(node, env, result, 'literal:function');
+      return result;
+    }
+
+    if (node instanceof ast.Call) {
+      const fn = evaluateNode(node.function_, env, node.line, node.column);
+      const args = evaluateExpressions(node.arguments_ ?? [], env, node.line ?? line, node.column ?? column);
+      const result = applyFunction(fn, args, node);
+      record(node, env, result, 'expression:call');
+      return result;
+    }
+
+    return NULL;
+  };
+
+  const evaluateBlockStatement = (block: ast.Block, env: Environment, line: number, column: number): RuntimeObject => {
+    let result: RuntimeObject = NULL;
+
+    for (const statement of block.statements) {
+      result = evaluateNode(statement, env, line, column);
+      if (result instanceof Return || result instanceof ErrorObj) {
+        return result;
+      }
+    }
+
+    return result;
+  };
+
+  const evaluateIfExpression = (node: ast.If, env: Environment): RuntimeObject => {
+    assertValue(node.condition);
+    const condition = evaluateNode(node.condition, env, node.line, node.column);
+
+    if (isTruthy(condition)) {
+      assertValue(node.consequence);
+      return evaluateNode(node.consequence, env, node.line, node.column);
+    }
+
+    if (node.alternative) {
+      return evaluateNode(node.alternative, env, node.line, node.column);
+    }
+
+    return NULL;
+  };
+
+  const evaluateExpressions = (
+    expressions: ast.Expression[],
+    env: Environment,
+    line: number,
+    column: number,
+  ): RuntimeObject[] => {
+    const result: RuntimeObject[] = [];
+    for (const expression of expressions) {
+      const evaluated = evaluateNode(expression, env, line, column);
+      result.push(evaluated);
     }
     return result;
-  } else {
-    return newError('NOT_A_FUNCTION', { line, column, name: fn.type() });
-  }
+  };
+
+  const applyFunction = (
+    fn: RuntimeObject,
+    args: RuntimeObject[],
+    callExpression: ast.Call,
+  ): RuntimeObject => {
+    if (fn instanceof RuntimeFunction) {
+      const frameName = callExpression.function_ instanceof ast.Identifier ? callExpression.function_.value : 'procedimiento';
+      state.tracer?.enterFrame({
+        name: frameName,
+        type: 'function',
+        location: { line: callExpression.line, column: callExpression.column },
+      });
+      const extendedEnv = extendFunctionEnv(fn, args);
+      const evaluated = evaluateNode(fn.body, extendedEnv, callExpression.line, callExpression.column);
+      state.tracer?.exitFrame();
+      return unwrapReturnValue(evaluated);
+    }
+
+    if (fn instanceof Builtin) {
+      const frameName = callExpression.function_ instanceof ast.Identifier ? callExpression.function_.value : 'builtin';
+      state.tracer?.enterFrame({
+        name: frameName,
+        type: 'builtin',
+        location: { line: callExpression.line, column: callExpression.column },
+      });
+      const result = fn.fn(...args);
+      state.tracer?.exitFrame();
+      if (result instanceof ErrorObj) {
+        return newError('GENERIC_ERROR', {
+          message: result.message,
+          line: callExpression.line ?? 0,
+          column: callExpression.column ?? 0,
+        });
+      }
+      return result;
+    }
+
+    return newError('NOT_A_FUNCTION', {
+      line: callExpression.line ?? 0,
+      column: callExpression.column ?? 0,
+      name: fn.type(),
+    });
+  };
+
+  const evaluateIdentifier = (node: ast.Identifier, env: Environment, line: number, column: number): RuntimeObject => {
+    if (isReservedWord(node.tokenLiteral())) {
+      return newError('RESERVED_WORD', { name: node.value, line, column });
+    }
+    const value = env.get(node.value);
+    if (!value) {
+      if (builtins[node.value]) {
+        return builtins[node.value];
+      }
+      return newError('UNKNOWN_IDENTIFIER', { name: node.value, line, column });
+    }
+    return value;
+  };
+
+  return {
+    evaluate: evaluateNode,
+    tracer,
+  };
 };
+
+export const evaluate = (
+  node: ast.ASTNode,
+  env: Environment,
+  options: EvaluationOptions = {},
+): RuntimeObject => {
+  const evaluator = createEvaluator(options);
+  return evaluator.evaluate(node, env, node.line, node.column);
+};
+
+const shouldInstantiateTracer = (options: EvaluationOptions): boolean => {
+  return Boolean(options.stepMode) || Boolean(options.breakpoints && options.breakpoints.length > 0);
+};
+
 const assertValue = (value: unknown): void => {
   if (value === null || value === undefined) {
     const err = new Error('value is null or undefined');
@@ -112,7 +310,7 @@ const assertNumber = (value: unknown): void => {
   }
 };
 
-const evaluateBangOperatorExpression = (right: Object): Object => {
+const evaluateBangOperatorExpression = (right: RuntimeObject): RuntimeObject => {
   switch (right) {
     case TRUE:
       return FALSE;
@@ -125,136 +323,66 @@ const evaluateBangOperatorExpression = (right: Object): Object => {
   }
 };
 
-const evaluateExpression = (
-  expressions: ast.Expression[],
-  env: Environment,
+const evaluatePrefixExpression = (
+  operator: string,
+  right: RuntimeObject,
   line: number,
   column: number,
-): Object[] => {
-  const result: Object[] = [];
-  for (const expression of expressions) {
-    const evaluated = evaluate(expression, env, line, column);
-    assertValue(evaluated);
-    result.push(evaluated);
-  }
-  return result;
-};
-
-const evaluateIdentifier = (node: ast.Identifier, env: Environment, line: number, column: number): Object => {
-  if (isReservedWord(node.tokenLiteral())) {
-    return newError('RESERVED_WORD', { name: node.value, line, column });
-  }
-  const value = env.get(node.value);
-  if (!value) {
-    if (builtins[node.value]) {
-      return builtins[node.value];
-    }
-    return newError('UNKNOWN_IDENTIFIER', { name: node.value, line, column });
-  }
-
-  return value;
-};
-
-const isReservedWord = (word: string): boolean => {
-  return reservedKeywords.includes(word);
-};
-
-const evaluateBooleanInfixExpression = (
-  nodeOperator: string,
-  left: Boolean,
-  right: Boolean,
-  line: number,
-  column: number,
-): Object => {
-  switch (nodeOperator) {
-    case '==':
-      return toBooleanObject(left.value === right.value);
-    case '!=':
-      return toBooleanObject(left.value !== right.value);
+): RuntimeObject => {
+  switch (operator) {
+    case '!':
+      return evaluateBangOperatorExpression(right);
+    case '-':
+      return evaluateMinusPrefixOperatorExpression(right, line, column);
     default:
-      return newError('UNKNOWN_INFIX_OPERATOR', {
-        operator: nodeOperator,
-        left: left.type(),
-        right: right.type(),
-        line,
-        column,
-      });
+      return newError('UNKNOWN_PREFIX_OPERATOR', { operator, right: right.type(), line, column });
   }
 };
 
-const evaluateIfExpression = (node: ast.If, env: Environment): Object => {
-  assertValue(node.condition);
-  const condition = evaluate(node.condition, env, node.line, node.column);
-  assertValue(condition);
-
-  if (isTruthy(condition)) {
-    assertValue(node.consequence);
-    return evaluate(node.consequence, env, node.line, node.column);
-  } else if (node.alternative) {
-    assertValue(node.alternative);
-    return evaluate(node.alternative, env, node.line, node.column);
-  } else {
-    return NULL;
+const evaluateMinusPrefixOperatorExpression = (right: RuntimeObject, line: number, column: number): RuntimeObject => {
+  if (!(right instanceof NumberObj)) {
+    return newError('UNKNOWN_PREFIX_OPERATOR', { operator: '-', right: right.type(), line, column });
   }
-};
-
-const isTruthy = (obj: Object): boolean => {
-  switch (obj) {
-    case NULL:
-      return false;
-    case TRUE:
-      return true;
-    case FALSE:
-      return false;
-    default:
-      return true;
-  }
+  const value = right.value;
+  return new NumberObj(-value);
 };
 
 const evaluateInfixExpression = (
-  nodeOperator: string,
-  left: Object,
-  right: Object,
+  operator: string,
+  left: RuntimeObject,
+  right: RuntimeObject,
   line: number,
   column: number,
-): Object => {
+): RuntimeObject => {
   if (left instanceof NumberObj && right instanceof NumberObj) {
-    return evaluateNumberInfixExpression(nodeOperator, left, right, line, column);
-  } else if (left instanceof String && right instanceof String) {
-    return evaluateStringInfixExpression(nodeOperator, left, right, line, column);
-  } else if (nodeOperator === '==') {
-    return toBooleanObject(left === right);
-  } else if (nodeOperator === '!=') {
-    return toBooleanObject(left !== right);
-  } else if (left instanceof Boolean && right instanceof Boolean) {
-    return evaluateBooleanInfixExpression(nodeOperator, left, right, line, column);
-  } else if (left.type() !== right.type()) {
-    return newError('TYPE_MISMATCH', {
-      operator: nodeOperator,
-      left: left.type(),
-      right: right.type(),
-      line,
-      column,
-    });
-  } else {
-    return newError('UNKNOWN_OPERATOR', {
-      operator: nodeOperator,
-      left: left.type(),
-      right: right.type(),
-      line,
-      column,
-    });
+    return evaluateNumberInfixExpression(operator, left, right, line, column);
   }
+  if (left instanceof StringObj && right instanceof StringObj) {
+    return evaluateStringInfixExpression(operator, left, right, line, column);
+  }
+  if (operator === '==') {
+    return toBooleanObject(left === right);
+  }
+  if (operator === '!=') {
+    return toBooleanObject(left !== right);
+  }
+  if (left instanceof BooleanObj && right instanceof BooleanObj) {
+    return evaluateBooleanInfixExpression(operator, left, right, line, column);
+  }
+  if (left.type() !== right.type()) {
+    return newError('TYPE_MISMATCH', { operator, left: left.type(), right: right.type(), line, column });
+  }
+  return newError('UNKNOWN_OPERATOR', { operator, left: left.type(), right: right.type(), line, column });
 };
 
 const evaluateNumberInfixExpression = (
-  nodeOperator: string,
+  operator: string,
   left: NumberObj,
   right: NumberObj,
   line: number,
   column: number,
-): Object => {
-  switch (nodeOperator) {
+): RuntimeObject => {
+  switch (operator) {
     case '+':
       return new NumberObj(left.value + right.value);
     case '-':
@@ -278,7 +406,7 @@ const evaluateNumberInfixExpression = (
     default:
       return newError('UNKNOWN_INFIX_OPERATOR', {
         type1: left.type(),
-        operator: nodeOperator,
+        operator,
         type2: right.type(),
         line,
         column,
@@ -287,18 +415,18 @@ const evaluateNumberInfixExpression = (
 };
 
 const evaluateStringInfixExpression = (
-  nodeOperator: string,
-  left: String,
-  right: String,
+  operator: string,
+  left: StringObj,
+  right: StringObj,
   line: number,
   column: number,
-): Object => {
+): RuntimeObject => {
   const leftValue = left.value;
   const rightValue = right.value;
 
-  switch (nodeOperator) {
+  switch (operator) {
     case '+':
-      return new String(leftValue + rightValue);
+      return new StringObj(leftValue + rightValue);
     case '==':
       return toBooleanObject(leftValue === rightValue);
     case '!=':
@@ -306,7 +434,7 @@ const evaluateStringInfixExpression = (
     default:
       return newError('UNKNOWN_INFIX_OPERATOR', {
         left: left.type(),
-        operator: nodeOperator,
+        operator,
         right: right.type(),
         line,
         column,
@@ -314,72 +442,61 @@ const evaluateStringInfixExpression = (
   }
 };
 
-const evaluateMinusPrefixOperatorExpression = (right: Object, line: number, column: number): Object => {
-  if (!(right instanceof NumberObj)) {
-    return newError('UNKNOWN_PREFIX_OPERATOR', { operator: '-', right: right.type(), line, column });
-  }
-
-  const value = right.value;
-  return new NumberObj(-value);
-};
-
-const evaluateProgram = (program: ast.Program, env: Environment, line?: number, column?: number): Object => {
-  let result: Object;
-
-  for (const statement of program.statements) {
-    result = evaluate(statement, env, line, column);
-    if (result instanceof Return) {
-      return result.value;
-    } else if (result instanceof Error) {
-      return result;
-    }
-  }
-
-  return result;
-};
-
-const evaluateBlockStatement = (block: ast.Block, env: Environment, line: number, column: number): Object => {
-  let result: Object;
-
-  for (const statement of block.statements) {
-    result = evaluate(statement, env, line, column);
-
-    if (result instanceof Return || result instanceof Error) {
-      return result;
-    }
-  }
-
-  return result;
-};
-
-const evaluatePrefixExpression = (operator: string, right: Object, line: number, column: number): Object => {
+const evaluateBooleanInfixExpression = (
+  operator: string,
+  left: BooleanObj,
+  right: BooleanObj,
+  line: number,
+  column: number,
+): RuntimeObject => {
   switch (operator) {
-    case '!':
-      return evaluateBangOperatorExpression(right);
-    case '-':
-      return evaluateMinusPrefixOperatorExpression(right, line, column);
+    case '==':
+      return toBooleanObject(left.value === right.value);
+    case '!=':
+      return toBooleanObject(left.value !== right.value);
     default:
-      return newError('UNKNOWN_PREFIX_OPERATOR', { operator, right: right.type(), line, column });
+      return newError('UNKNOWN_INFIX_OPERATOR', {
+        operator,
+        left: left.type(),
+        right: right.type(),
+        line,
+        column,
+      });
   }
 };
 
-const toBooleanObject = (value: boolean): Boolean => {
+const toBooleanObject = (value: boolean): BooleanObj => {
   return value ? TRUE : FALSE;
 };
 
-const extendFunctionEnv = (fn: Function, args: Object[]): Environment => {
-  const env = new Environment(fn.env);
-
-  for (let i = 0; i < fn.parameters.length; i++) {
-    env.set(fn.parameters[i].value, args[i]);
+const extendFunctionEnv = (fn: RuntimeFunction, args: RuntimeObject[]): Environment => {
+  const extended = new Environment(fn.env);
+  for (let index = 0; index < fn.parameters.length; index++) {
+    extended.set(fn.parameters[index].value, args[index]);
   }
-  return env;
+  return extended;
 };
 
-const unwrapReturnValue = (obj: Object): Object => {
+const unwrapReturnValue = (obj: RuntimeObject): RuntimeObject => {
   if (obj instanceof Return) {
     return obj.value;
   }
-
   return obj;
+};
+
+const isTruthy = (obj: RuntimeObject): boolean => {
+  switch (obj) {
+    case NULL:
+      return false;
+    case TRUE:
+      return true;
+    case FALSE:
+      return false;
+    default:
+      return true;
+  }
+};
+
+const isReservedWord = (word: string): boolean => {
+  return reservedKeywords.includes(word);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,15 @@
 export * from './token';
 export { Lexer } from './lexer';
 export { Parser } from './parser';
-export { evaluate } from './evaluator';
+export { evaluate, createEvaluator } from './evaluator';
 export { newError } from './errors';
 export { builtins } from './builtins';
 export { inspect } from './inspector';
 export * as ast from './ast';
 export * as runtime from './object';
+export { serializeProgram, serializeNode } from './astSerializer';
+export type { SerializedASTNode, SerializedASTChild } from './astSerializer';
+export { CodexivoEngine } from './engine';
+export { RuntimeTracer } from './runtime/tracer';
+export type { RuntimeTrace, TraceEvent, Breakpoint } from './runtime/tracer';
+export type { EvaluationOptions } from './evaluator';

--- a/src/object.ts
+++ b/src/object.ts
@@ -106,14 +106,20 @@ export class Environment {
 }
 
 export class Function implements Object {
-  constructor(public parameters: Identifier[], public body: Block, public env: Environment) {}
+  constructor(
+    public parameters: Identifier[],
+    public body: Block,
+    public env: Environment,
+    public name?: string,
+  ) {}
 
   type(): ObjectType {
     return ObjectType.FUNCTION;
   }
 
   inspect(): string {
-    return `procedimiento(${this.parameters.map(p => p.toString()).join(', ')}) {\n${this.body.statements
+    const header = this.name ? `${this.name} = ` : '';
+    return `${header}procedimiento(${this.parameters.map(p => p.toString()).join(', ')}) {\n${this.body.statements
       .map(s => s.toString())
       .join('\n')}\n}`;
   }

--- a/src/runtime/tracer.ts
+++ b/src/runtime/tracer.ts
@@ -1,0 +1,441 @@
+import * as ast from '../ast';
+import {
+  Boolean as BooleanObj,
+  Builtin,
+  Environment,
+  Error as ErrorObj,
+  Function as RuntimeFunction,
+  Null,
+  Number as NumberObj,
+  Object as RuntimeObject,
+  Return,
+  String as StringObj,
+} from '../object';
+
+export interface Breakpoint {
+  line: number;
+  column?: number;
+  once?: boolean;
+  label?: string;
+}
+
+export interface RuntimeTracerOptions {
+  breakpoints?: Breakpoint[];
+  stepMode?: boolean;
+}
+
+export interface RuntimeValueSnapshot {
+  type: string;
+  value: unknown;
+  repr: string;
+}
+
+export interface ScopeSnapshot {
+  level: number;
+  variables: Record<string, RuntimeValueSnapshot>;
+}
+
+export interface EnvironmentSnapshot {
+  scopes: ScopeSnapshot[];
+}
+
+export type EnvironmentChangeType = 'add' | 'update' | 'delete';
+
+export interface EnvironmentChange {
+  scope: number;
+  name: string;
+  type: EnvironmentChangeType;
+  before?: RuntimeValueSnapshot;
+  after?: RuntimeValueSnapshot;
+}
+
+export type CallFrameType = 'program' | 'function' | 'builtin';
+
+export interface CallFrame {
+  name: string;
+  type: CallFrameType;
+  location?: { line?: number; column?: number };
+}
+
+export type IOEventType = 'input' | 'output';
+
+export interface IOEvent {
+  type: IOEventType;
+  value: unknown;
+  at?: { line?: number; column?: number };
+}
+
+export interface TraceEvent {
+  step: number;
+  nodeType: string;
+  operation: string;
+  position: { line: number; column: number };
+  metadata: Record<string, unknown>;
+  environment: EnvironmentSnapshot;
+  changes: EnvironmentChange[];
+  callStack: CallFrame[];
+  result?: RuntimeValueSnapshot;
+  breakpoint: boolean;
+  stepMode: boolean;
+  ioEvents: IOEvent[];
+}
+
+export interface RuntimeTrace {
+  events: TraceEvent[];
+  breakpoints: Breakpoint[];
+  io: IOEvent[];
+}
+
+export class RuntimeTracer implements Iterable<TraceEvent> {
+  private readonly options: Required<RuntimeTracerOptions>;
+  private readonly events: TraceEvent[] = [];
+  private readonly breakpointMap: Map<string, Breakpoint> = new Map();
+  private callStack: CallFrame[] = [];
+  private ioEvents: IOEvent[] = [];
+  private ioLog: IOEvent[] = [];
+  private lastSnapshot: EnvironmentSnapshot | null = null;
+  private stepCounter = 0;
+  private readIndex = 0;
+
+  constructor(options: RuntimeTracerOptions = {}) {
+    this.options = {
+      breakpoints: options.breakpoints ?? [],
+      stepMode: options.stepMode ?? false,
+    };
+
+    for (const breakpoint of this.options.breakpoints) {
+      this.registerBreakpoint(breakpoint);
+    }
+  }
+
+  public enterFrame(frame: CallFrame): void {
+    this.callStack = [...this.callStack, frame];
+  }
+
+  public exitFrame(): void {
+    if (this.callStack.length === 0) {
+      return;
+    }
+    this.callStack = this.callStack.slice(0, this.callStack.length - 1);
+  }
+
+  public recordIO(event: IOEvent): void {
+    this.ioEvents = [...this.ioEvents, event];
+    this.ioLog = [...this.ioLog, event];
+  }
+
+  public addBreakpoint(breakpoint: Breakpoint): void {
+    this.registerBreakpoint(breakpoint);
+  }
+
+  public clearBreakpoints(): void {
+    this.breakpointMap.clear();
+  }
+
+  public setStepMode(enabled: boolean): void {
+    this.options.stepMode = enabled;
+  }
+
+  public nextStep(): TraceEvent | undefined {
+    if (this.readIndex >= this.events.length) {
+      return undefined;
+    }
+    const event = this.events[this.readIndex];
+    this.readIndex += 1;
+    return event;
+  }
+
+  public resetSteps(): void {
+    this.readIndex = 0;
+  }
+
+  public record({
+    node,
+    env,
+    result,
+    operation,
+  }: {
+    node: ast.ASTNode;
+    env: Environment;
+    result?: RuntimeObject;
+    operation: string;
+  }): TraceEvent {
+    const environment = this.snapshotEnvironment(env);
+    const changes = this.computeChanges(environment);
+    this.lastSnapshot = environment;
+
+    const event: TraceEvent = {
+      step: ++this.stepCounter,
+      nodeType: node.constructor.name,
+      operation,
+      position: {
+        line: node.line ?? 0,
+        column: node.column ?? 0,
+      },
+      environment,
+      changes,
+      callStack: [...this.callStack],
+      metadata: this.describeNode(node),
+      result: this.serializeObject(result),
+      breakpoint: this.matchBreakpoint(node.line, node.column),
+      stepMode: this.options.stepMode,
+      ioEvents: this.consumeIOEvents(),
+    };
+
+    this.events.push(event);
+
+    return event;
+  }
+
+  public getTrace(): RuntimeTrace {
+    return {
+      events: [...this.events],
+      breakpoints: this.listBreakpoints(),
+      io: [...this.ioLog],
+    };
+  }
+
+  public [Symbol.iterator](): Iterator<TraceEvent> {
+    return this.events[Symbol.iterator]();
+  }
+
+  private registerBreakpoint(breakpoint: Breakpoint): void {
+    this.breakpointMap.set(this.getBreakpointKey(breakpoint.line, breakpoint.column), breakpoint);
+    if (breakpoint.column === undefined) {
+      this.breakpointMap.set(this.getBreakpointKey(breakpoint.line, undefined), breakpoint);
+    }
+  }
+
+  private listBreakpoints(): Breakpoint[] {
+    const uniqueKeys = new Set<string>();
+    const breakpoints: Breakpoint[] = [];
+
+    for (const [key, breakpoint] of this.breakpointMap.entries()) {
+      const signature = `${breakpoint.line}:${breakpoint.column ?? '*'}:${breakpoint.label ?? ''}`;
+      if (uniqueKeys.has(signature)) {
+        continue;
+      }
+      uniqueKeys.add(signature);
+      breakpoints.push(breakpoint);
+    }
+
+    return breakpoints;
+  }
+
+  private consumeIOEvents(): IOEvent[] {
+    if (this.ioEvents.length === 0) {
+      return [];
+    }
+    const events = [...this.ioEvents];
+    this.ioEvents = [];
+    return events;
+  }
+
+  private getBreakpointKey(line?: number, column?: number): string {
+    return `${line ?? -1}:${column ?? -1}`;
+  }
+
+  private matchBreakpoint(line?: number, column?: number): boolean {
+    if (line === undefined) {
+      return false;
+    }
+
+    const exact = this.breakpointMap.get(this.getBreakpointKey(line, column));
+    const byLine = this.breakpointMap.get(this.getBreakpointKey(line, undefined));
+    const matched = exact ?? byLine;
+
+    if (!matched) {
+      return false;
+    }
+
+    if (matched.once) {
+      this.breakpointMap.delete(this.getBreakpointKey(matched.line, matched.column));
+      if (matched.column === undefined) {
+        this.breakpointMap.delete(this.getBreakpointKey(matched.line, undefined));
+      }
+    }
+
+    return true;
+  }
+
+  private snapshotEnvironment(env: Environment): EnvironmentSnapshot {
+    const scopes: ScopeSnapshot[] = [];
+    const chain: Environment[] = [];
+    let current: Environment | undefined = env;
+
+    while (current) {
+      chain.push(current);
+      current = current.outer;
+    }
+
+    chain.reverse().forEach((scopeEnv, index) => {
+      const variables: Record<string, RuntimeValueSnapshot> = {};
+      for (const [name, value] of scopeEnv.store.entries()) {
+        variables[name] = this.serializeObject(value) ?? {
+          type: 'UNKNOWN',
+          value: undefined,
+          repr: 'indefinido',
+        };
+      }
+      scopes.push({ level: index, variables });
+    });
+
+    return { scopes };
+  }
+
+  private computeChanges(current: EnvironmentSnapshot): EnvironmentChange[] {
+    if (!this.lastSnapshot) {
+      const initialChanges: EnvironmentChange[] = [];
+      current.scopes.forEach(scope => {
+        for (const [name, snapshot] of Object.entries(scope.variables)) {
+          initialChanges.push({
+            scope: scope.level,
+            name,
+            type: 'add',
+            after: snapshot,
+          });
+        }
+      });
+      return initialChanges;
+    }
+
+    const changes: EnvironmentChange[] = [];
+    const maxLength = Math.max(current.scopes.length, this.lastSnapshot.scopes.length);
+
+    for (let index = 0; index < maxLength; index++) {
+      const currentScope = current.scopes[index];
+      const previousScope = this.lastSnapshot.scopes[index];
+      const currentVariables = currentScope?.variables ?? {};
+      const previousVariables = previousScope?.variables ?? {};
+
+      for (const [name, snapshot] of Object.entries(currentVariables)) {
+        if (!(name in previousVariables)) {
+          changes.push({ scope: currentScope.level, name, type: 'add', after: snapshot });
+        } else if (!this.valueEquals(previousVariables[name], snapshot)) {
+          changes.push({
+            scope: currentScope.level,
+            name,
+            type: 'update',
+            before: previousVariables[name],
+            after: snapshot,
+          });
+        }
+      }
+
+      for (const [name, snapshot] of Object.entries(previousVariables)) {
+        if (!(name in currentVariables)) {
+          changes.push({ scope: previousScope.level, name, type: 'delete', before: snapshot });
+        }
+      }
+    }
+
+    return changes;
+  }
+
+  private valueEquals(a?: RuntimeValueSnapshot, b?: RuntimeValueSnapshot): boolean {
+    if (!a || !b) {
+      return false;
+    }
+    return a.type === b.type && JSON.stringify(a.value) === JSON.stringify(b.value);
+  }
+
+  private serializeObject(obj?: RuntimeObject): RuntimeValueSnapshot | undefined {
+    if (!obj) {
+      return undefined;
+    }
+
+    if (obj instanceof NumberObj) {
+      return { type: obj.type(), value: obj.value, repr: obj.inspect() };
+    }
+
+    if (obj instanceof BooleanObj) {
+      return { type: obj.type(), value: obj.value, repr: obj.inspect() };
+    }
+
+    if (obj instanceof StringObj) {
+      return { type: obj.type(), value: obj.value, repr: obj.inspect() };
+    }
+
+    if (obj instanceof Null) {
+      return { type: obj.type(), value: null, repr: obj.inspect() };
+    }
+
+    if (obj instanceof ErrorObj) {
+      return { type: obj.type(), value: obj.message, repr: obj.inspect() };
+    }
+
+    if (obj instanceof Return) {
+      const inner = this.serializeObject(obj.value);
+      return {
+        type: obj.type(),
+        value: inner?.value ?? null,
+        repr: inner?.repr ?? obj.inspect(),
+      };
+    }
+
+    if (obj instanceof RuntimeFunction) {
+      return {
+        type: obj.type(),
+        value: {
+          parameters: obj.parameters.map(parameter => parameter.value),
+          hasName: Boolean(obj.name),
+        },
+        repr: obj.inspect(),
+      };
+    }
+
+    if (obj instanceof Builtin) {
+      return {
+        type: obj.type(),
+        value: 'builtin',
+        repr: obj.inspect(),
+      };
+    }
+
+    return { type: 'UNKNOWN', value: undefined, repr: 'indefinido' };
+  }
+
+  private describeNode(node: ast.ASTNode): Record<string, unknown> {
+    const metadata: Record<string, unknown> = { type: node.constructor.name };
+
+    if (node instanceof ast.Program) {
+      metadata.kind = 'Program';
+      metadata.size = node.statements.length;
+    } else if (node instanceof ast.Statement) {
+      metadata.kind = 'Statement';
+    } else if (node instanceof ast.Expression) {
+      metadata.kind = 'Expression';
+    }
+
+    if (node instanceof ast.LetStatement) {
+      metadata.identifier = node.name?.value ?? null;
+    }
+
+    if (node instanceof ast.Identifier) {
+      metadata.name = node.value;
+    }
+
+    if (node instanceof ast.Call) {
+      metadata.arguments = node.arguments_?.length ?? 0;
+    }
+
+    if (node instanceof ast.Function) {
+      metadata.parameters = node.parameters?.map(parameter => parameter.value) ?? [];
+      metadata.name = node.name?.value ?? null;
+    }
+
+    if (node instanceof ast.Number) {
+      metadata.value = node.value;
+    }
+
+    if (node instanceof ast.Boolean) {
+      metadata.value = node.value;
+    }
+
+    if (node instanceof ast.StringLiteral) {
+      metadata.value = node.value;
+    }
+
+    return metadata;
+  }
+}

--- a/src/tests/engine.spec.ts
+++ b/src/tests/engine.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'bun:test';
+
+import { CodexivoEngine } from '../engine';
+import { Number as NumberObj } from '../object';
+
+describe('CodexivoEngine', () => {
+  it('exposes AST metadata with parent-child relationships and positions', () => {
+    const engine = new CodexivoEngine();
+    const source = `variable total = 5;\ntotal;`;
+    const { ast, errors } = engine.getAST(source);
+
+    expect(errors).toEqual([]);
+    expect(ast).not.toBeNull();
+
+    const program = ast!;
+    expect(program.type).toBe('Program');
+    expect(program.position.line).toBe(1);
+    expect(program.parentId).toBeNull();
+    expect(program.children.length).toBeGreaterThan(0);
+
+    const letChild = program.children.find(child => child.node.type === 'LetStatement');
+    expect(letChild).toBeDefined();
+    expect(letChild!.relation).toBe('statement');
+    expect(letChild!.node.parentId).toBe(program.id);
+    expect(letChild!.node.metadata.identifier).toBe('total');
+    expect(letChild!.node.position.line).toBe(1);
+
+    const valueChild = letChild!.node.children.find(child => child.relation === 'value');
+    expect(valueChild).toBeDefined();
+    expect(valueChild!.node.type).toBe('Number');
+    expect(valueChild!.node.metadata.value).toBe(5);
+    expect(valueChild!.node.position.column).toBeGreaterThan(0);
+  });
+
+  it('runs code with runtime tracing, breakpoints, and state snapshots', () => {
+    const engine = new CodexivoEngine();
+    const source = `
+variable a = 1;
+variable incrementar = procedimiento(valor) {
+  variable siguiente = valor + 1;
+  regresa siguiente;
+};
+variable resultado = incrementar(a);
+resultado;
+`.trim();
+
+    const { result, trace, errors } = engine.run(source, {
+      trace: true,
+      stepMode: true,
+      breakpoints: [{ line: 4 }],
+    });
+
+    expect(errors).toEqual([]);
+    expect(result).toBeInstanceOf(NumberObj);
+    expect((result as NumberObj).value).toBe(2);
+    expect(trace).toBeDefined();
+    expect(trace!.events.length).toBeGreaterThan(0);
+
+    const breakpointEvent = trace!.events.find(event => event.breakpoint);
+    expect(breakpointEvent).toBeDefined();
+    expect(breakpointEvent!.position.line).toBe(4);
+
+    const letEvent = trace!.events.find(event => event.nodeType === 'LetStatement' && event.metadata?.identifier === 'resultado');
+    expect(letEvent).toBeDefined();
+    expect(letEvent!.changes.some(change => change.name === 'resultado')).toBe(true);
+    expect(letEvent!.environment.scopes[0].variables.resultado.value).toBe(2);
+
+    const innerLet = trace!.events.find(
+      event => event.nodeType === 'LetStatement' && event.metadata?.identifier === 'siguiente',
+    );
+    expect(innerLet).toBeDefined();
+    expect(innerLet!.callStack.some(frame => frame.type === 'function')).toBe(true);
+
+    const stepIterator = trace!.events[Symbol.iterator]();
+    expect(stepIterator.next().done).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a CodexivoEngine facade to parse, inspect, and execute programs with optional tracing
- serialize AST nodes to structured JSON with metadata, parent links, and child relations
- refactor evaluation to drive the new RuntimeTracer and export the supporting APIs

## Testing
- bun test
- bun run types

------
https://chatgpt.com/codex/tasks/task_e_68d6cefaffe0832bb992a248423327d4