### PR TITLE
docs: add reference documentation for Codexivo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# Documentación de Codexivo
+
+Bienvenido al compendio oficial del lenguaje **Codexivo**. Este directorio recopila guías para dos audiencias principales:
+
+1. **Personas que desean escribir programas en Codexivo** y necesitan una referencia clara de la sintaxis, los tipos y las herramientas disponibles.
+2. **Personas que quieren entender cómo está construido el intérprete** para poder extenderlo, depurarlo o utilizarlo como recurso educativo.
+
+## Guías disponibles
+
+- [Especificación del lenguaje](./lenguaje.md): describe la sintaxis, palabras reservadas, tipos de dato y reglas semánticas que definen a Codexivo como si fuera un lenguaje formal.
+- [Arquitectura del intérprete](./arquitectura.md): recorre el código fuente módulo por módulo para explicar cómo se procesa un programa desde el texto hasta su evaluación.
+- [Uso del REPL y flujo de trabajo](./repl.md): muestra cómo ejecutar el intérprete, guardar sesiones y aprovechar las herramientas de trazado en tiempo real.
+- [Recetario de programas](./recetario.md): colección de ejemplos completos que ilustran patrones comunes de solución.
+
+> ℹ️ Las guías están pensadas para leerse de forma progresiva. Si tu objetivo es aprender el lenguaje, comienza por la especificación y luego pon en práctica los ejemplos del recetario. Si deseas contribuir al código, revisa primero la arquitectura y después ejecuta los escenarios del REPL.
+
+## Convenciones
+
+- Todo el contenido está en español y emplea la terminología oficial del proyecto ("procedimiento", "variable", etc.).
+- Los bloques de código usan resaltado de sintaxis cuando aplica para facilitar la lectura comparando con JavaScript.
+- Las referencias al código fuente incluyen rutas y nombres de clases/funciones exactas para que puedas ubicarlas rápidamente.
+
+¡Disfruta explorando Codexivo!

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Bienvenido al compendio oficial del lenguaje **Codexivo**. Este directorio recop
 
 - [Especificación del lenguaje](./lenguaje.md): describe la sintaxis, palabras reservadas, tipos de dato y reglas semánticas que definen a Codexivo como si fuera un lenguaje formal.
 - [Arquitectura del intérprete](./arquitectura.md): recorre el código fuente módulo por módulo para explicar cómo se procesa un programa desde el texto hasta su evaluación.
+- [Guía práctica: entender el intérprete desde el código](./guia-aprender-desde-el-codigo.md): actividades guiadas para relacionar cada módulo con ejemplos reales del lenguaje.
 - [Uso del REPL y flujo de trabajo](./repl.md): muestra cómo ejecutar el intérprete, guardar sesiones y aprovechar las herramientas de trazado en tiempo real.
 - [Recetario de programas](./recetario.md): colección de ejemplos completos que ilustran patrones comunes de solución.
 

--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -94,6 +94,9 @@ como en tipo de argumentos. 【F:src/builtins.ts†L1-L16】
 ## 9. Trazado en tiempo real (`src/runtime/tracer.ts`)
 
 `RuntimeTracer` captura cada paso del evaluador: el nodo visitado, el estado del entorno, la pila de llamadas y eventos de E/S.
+<!--
+**RuntimeTracer**: La herramienta permite recorrer la ejecución en modo paso a paso, avanzando una instrucción cada vez para observar cómo cambian las variables tras cada operación. También admite puntos de interrupción personalizados, en los que la traza se detiene cuando se cumple una condición específica (por ejemplo, `if (contador > 10)`). Para usar ambas funciones en conjunto, activa el modo paso a paso y define un punto de interrupción; la ejecución continuará instrucción por instrucción hasta alcanzar la condición, momento en el que podrás inspeccionar el estado del programa antes de reanudar.
+-->
 Se puede activar en modo paso a paso o con puntos de interrupción personalizados. Esta herramienta es clave para aprender cómo se
 modifican las variables y entender el flujo de ejecución. 【F:src/runtime/tracer.ts†L1-L173】
 

--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -1,0 +1,107 @@
+# Arquitectura interna del intérprete
+
+Este documento explica cómo está implementado Codexivo para que estudiantes y contribuyentes entiendan el flujo completo desde
+el texto fuente hasta la ejecución. Sigue el orden real en el que intervienen los módulos de `src/`.
+
+## 1. Motor de orquestación (`src/engine.ts`)
+
+`CodexivoEngine` centraliza las operaciones de parseo, generación de AST, ejecución y trazado. Expone tres métodos principales:
+
+- `parse` crea un `Lexer`, un `Parser` y devuelve el `Program` junto con los errores sintácticos acumulados.
+- `getAST` serializa el programa para herramientas de visualización usando `astSerializer.ts`.
+- `run` reutiliza `parse`, configura el entorno y delega en el evaluador; opcionalmente activa un `RuntimeTracer` para capturar el
+  recorrido. 【F:src/engine.ts†L1-L83】
+
+Comprender este motor te permite construir interfaces (REPL, web) sobre una API consistente.
+
+## 2. Análisis léxico (`src/lexer.ts`)
+
+El `Lexer` recorre el código carácter a carácter y produce instancias de `Token`. Mantiene punteros de posición, línea y columna
+para enriquecer los mensajes de error. Entre sus responsabilidades destacan:
+
+- Ignorar espacios en blanco y saltos de línea (`skipWhitespace`).
+- Reconocer operadores de uno y dos caracteres (`makeTwoCharacterToken`).
+- Leer identificadores/keywords, números (enteros y decimales) y cadenas con comillas simples o dobles. 【F:src/lexer.ts†L1-L117】
+
+El mapeo de palabras reservadas se realiza con `lookupIdentifier` en `token.ts`. Si el literal no coincide, se clasifica como
+identificador genérico. 【F:src/token.ts†L44-L77】
+
+## 3. Árbol de sintaxis abstracta (`src/ast.ts`)
+
+Cada nodo del AST extiende las clases base `Statement` o `Expression`. Se guardan el token de origen, línea y columna para poder
+serializar y depurar. Algunos nodos clave:
+
+- `Program`: raíz que agrupa todas las sentencias.
+- `LetStatement`, `ReturnStatement`, `ExpressionStatement`: representan las instrucciones de alto nivel.
+- `If`, `While`, `DoWhile`, `For`: encapsulan estructuras de control.
+- `Function` y `Call`: modelan procedimientos y sus invocaciones.
+- `StringLiteral`, `Boolean`, `Number`: literales primitivos. 【F:src/ast.ts†L1-L229】
+
+Estudiar estas clases es útil para añadir nuevas construcciones sin romper la serialización o el trazado.
+
+## 4. Análisis sintáctico (`src/parser.ts`)
+
+El parser implementa la técnica Pratt para resolver la precedencia de operadores. Mantiene un mapa de funciones de parseo por
+token (`registerPrefixParseFns` y `registerInfixParseFns`) y avanza en el flujo de tokens con `advanceTokens`.
+
+- `parseProgram` recorre los tokens hasta `EOF` y va agregando sentencias.
+- `parseLetStatement`, `parseReturnStatement` y `parseExpressionStatement` manejan las estructuras básicas.
+- `parseIf`, `parseFunction`, `parseCall`, `parseArray` y `parseIndexExpression` amplían las expresiones posibles.
+- Cuando se detecta una palabra reservada mal usada o falta un token esperado se agrega un mensaje legible al arreglo `_errors`.
+  【F:src/parser.ts†L1-L680】
+
+La modularidad facilita que cambies o amplíes la gramática simplemente registrando nuevas funciones.
+
+## 5. Objetos en tiempo de ejecución (`src/object.ts`)
+
+Los resultados de evaluar nodos del AST se representan con clases que implementan `Object`:
+
+- `Number`, `Boolean`, `String`, `Null` encapsulan tipos primitivos.
+- `Environment` es un mapa jerárquico que conserva valores y permite alcance léxico mediante una referencia `outer`.
+- `Function` guarda parámetros, cuerpo y el entorno donde se definió (clausuras).
+- `Builtin` envuelve funciones nativas escritas en TypeScript.
+- `Return` y `Error` permiten controlar el flujo interno del evaluador. 【F:src/object.ts†L1-L111】
+
+Dominar estas clases es crucial para agregar nuevas estructuras (por ejemplo, arreglos) sin reescribir el evaluador.
+
+## 6. Evaluación (`src/evaluator.ts`)
+
+`createEvaluator` devuelve un objeto con el método `evaluate` que aplica un `switch` implícito mediante `instanceof` sobre cada
+nodo del AST. El evaluador:
+
+- Recorre el programa sentencia por sentencia y propaga valores de retorno o errores.
+- Convierte literales en objetos de tiempo de ejecución (`NumberObj`, `StringObj`, etc.).
+- Maneja expresiones prefijas e infijas reutilizando funciones auxiliares (`evaluatePrefixExpression`, `evaluateInfixExpression`).
+- Resuelve identificadores consultando el `Environment` y, si falla, busca en los built-ins.
+- Crea entornos extendidos para ejecutar procedimientos y desenvuelve resultados con `unwrapReturnValue`.
+- Genera eventos para el `RuntimeTracer` cuando está activo, incluyendo cambios de variables. 【F:src/evaluator.ts†L1-L352】【F:src/evaluator.ts†L352-L462】
+
+Actualmente los nodos de bucle aún no tienen semántica evaluada; la infraestructura está lista para incorporarla en futuras
+iteraciones.
+
+## 7. Errores y mensajes (`src/errors.ts`)
+
+Los errores se centralizan en `newError`, que arma textos amigables en español indicando el tipo de problema, la posición y los
+datos relevantes (operadores, nombres, etc.). Esto ayuda a mantener consistencia en toda la experiencia del estudiante.
+【F:src/errors.ts†L1-L200】
+
+## 8. Funciones built-in (`src/builtins.ts`)
+
+Cada built-in es una función TypeScript que recibe y devuelve objetos de `object.ts`. Se registran en un diccionario para que el
+evaluador los exponga automáticamente al usuario sin redeclararlos. Por ahora solo existe `longitud`, validada tanto en número
+como en tipo de argumentos. 【F:src/builtins.ts†L1-L16】
+
+## 9. Trazado en tiempo real (`src/runtime/tracer.ts`)
+
+`RuntimeTracer` captura cada paso del evaluador: el nodo visitado, el estado del entorno, la pila de llamadas y eventos de E/S.
+Se puede activar en modo paso a paso o con puntos de interrupción personalizados. Esta herramienta es clave para aprender cómo se
+modifican las variables y entender el flujo de ejecución. 【F:src/runtime/tracer.ts†L1-L173】
+
+## Cómo estudiar el código
+
+1. Ejecuta `bun run repl` e ingresa programas simples.
+2. Usa `CodexivoEngine.getAST` para observar cómo el parser traduce tu código.
+3. Activa el tracer (`engine.run(source, { trace: true })`) y revisa los eventos generados.
+4. Experimenta modificando módulos individuales y ejecuta `bun test` para validar que el comportamiento siga siendo el esperado.
+
+Seguir estos pasos te permitirá avanzar desde escribir programas hasta comprender y extender el propio lenguaje Codexivo.

--- a/docs/guia-aprender-desde-el-codigo.md
+++ b/docs/guia-aprender-desde-el-codigo.md
@@ -1,0 +1,138 @@
+# Guía práctica: entender Codexivo desde su código
+
+Esta guía acompaña a estudiantes curiosos que ya escriben programas en Codexivo y ahora desean mirar "debajo del capó" para
+comprender cómo el intérprete procesa cada instrucción. Sigue los pasos en orden; cada apartado parte de un fragmento de código
+real y te señala exactamente qué archivos explorar para conectar la teoría con la implementación.
+
+## Objetivo
+
+- Relacionar cada fase del intérprete (léxico, sintaxis, evaluación) con el código real.
+- Dominar las herramientas disponibles para inspeccionar tokens, AST y el estado del entorno.
+- Proponer ejercicios concretos que consoliden el aprendizaje mientras modificas o amplías el lenguaje.
+
+## Preparación rápida
+
+1. Instala las dependencias con `bun install`.
+2. Ejecuta `bun run repl` para confirmar que el intérprete funciona.
+3. Abre este repositorio en tu editor favorito; mantén a mano los archivos de `src/` y los tests de `src/tests/`.
+
+Cuando quieras verificar que tus cambios no rompen nada, ejecuta `bun test`.
+
+## Mapa mental del flujo
+
+Antes de profundizar, revisa el motor unificado en `src/engine.ts:33`. `CodexivoEngine.run` se encarga de:
+
+- Crear un `Lexer` y un `Parser` (`src/lexer.ts:22`, `src/parser.ts:87`).
+- Construir el AST y manejar errores de análisis.
+- Instanciar el evaluador (`src/evaluator.ts:36`) y, si lo pides, activar el `RuntimeTracer` (`src/runtime/tracer.ts:89`).
+
+Ten presente este recorrido; cada actividad siguiente inspecciona una etapa concreta.
+
+## Actividad 1 · Escribe y ejecuta un programa semilla
+
+Lanza el REPL (`bun run repl`) y prueba el siguiente fragmento:
+
+```codexivo
+variable saludo = "Codexivo";
+procedimiento armaMensaje(nombre) {
+  variable prefijo = "Hola ";
+  regresa prefijo + nombre;
+}
+armaMensaje(saludo);
+```
+
+Observa el resultado y déjalo como punto de partida. Este código reaparece en cada actividad para que puedas comparar cómo se
+representa a distintos niveles.
+
+## Actividad 2 · Sigue los tokens producidos por el lexer
+
+1. Abre `src/lexer.ts:22`. `Lexer.nextToken` recorre el código carácter a carácter y produce instancias de `Token`.
+2. Revisa cómo se reconocen identificadores y palabras reservadas en `src/lexer.ts:115` junto con `lookupIdentifier` en
+   `src/token.ts:44`.
+3. Ejecuta `bun test src/tests/lexer.spec.ts` y localiza el caso "lexer function declaration" (`src/tests/lexer.spec.ts:101`):
+   compara los tokens esperados con los que obtuviste en el REPL.
+
+> 👩‍💻 Ejercicio breve: añade un carácter extra (por ejemplo, `#`) a tu programa semilla y vuelve a ejecutar `lexer.spec.ts` para
+> observar cómo se reportan tokens `ILLEGAL`.
+
+## Actividad 3 · Visualiza el árbol de sintaxis abstracta
+
+1. Inspecciona `parseProgram` en `src/parser.ts:87`. Observa cómo agrega sentencias al `Program` del AST.
+2. Dentro del mismo archivo, identifica `parseFunction` (`src/parser.ts:333`) y `parseCall`
+   (`src/parser.ts:173`): son los responsables de tus procedimientos y llamadas.
+3. Corre `bun test src/tests/parser.spec.ts` y busca el caso "parse function literal" (`src/tests/parser.spec.ts:496`). Verás
+   cómo se espera que se estructuren los nodos `Function` y `Call`.
+4. Si quieres una vista serializada del árbol, ejecuta este script desde un archivo temporal:
+
+```ts
+import { CodexivoEngine } from './src/engine';
+
+const engine = new CodexivoEngine();
+const programa = `variable saludo = "Codexivo";\nprocedimiento armaMensaje(nombre) { regresa nombre; }\narmaMensaje(saludo);`;
+const { ast, errors } = engine.getAST(programa, { includePositions: true });
+console.log(JSON.stringify(ast, null, 2));
+console.log(errors);
+```
+
+Observa cómo cada nodo indica línea y columna; estos datos provienen directamente del parser.
+
+## Actividad 4 · Recorre la evaluación paso a paso
+
+1. Revisa `createEvaluator` en `src/evaluator.ts:36`. Allí se decide si instanciar un `RuntimeTracer` y se define la función
+   interna `evaluateNode` (`src/evaluator.ts:44`).
+2. Sigue cómo se manejan los literales (`src/evaluator.ts:82`), las declaraciones `variable` (`src/evaluator.ts:143`) y las
+   invocaciones de procedimientos (`src/evaluator.ts:166`).
+3. Ejecuta `bun test src/tests/evaluator.spec.ts` y enfócate en el caso "should evaluate function call" (`src/tests/evaluator.spec.ts:217`) para verificar el comportamiento esperado.
+4. Para observar la ejecución en tiempo real, abre `src/runtime/tracer.ts:152` y fíjate en el método `record`. Luego, crea un
+   script mínimo:
+
+```ts
+import { CodexivoEngine } from './src/engine';
+
+const engine = new CodexivoEngine();
+const codigo = `variable saludo = "Codexivo";\nprocedimiento armaMensaje(nombre) { regresa nombre; }\narmaMensaje(saludo);`;
+const { trace } = engine.run(codigo, { trace: true });
+console.table(trace?.events.map(evento => ({
+  paso: evento.step,
+  nodo: evento.nodeType,
+  operacion: evento.operation,
+  resultado: evento.result?.repr,
+})));
+```
+
+Inspecciona cómo el tracer captura cada transición de entorno (`trace.events[0].changes`).
+
+## Actividad 5 · Explora el entorno y las clausuras
+
+- `Environment` implementa scopes anidados en `src/object.ts:77`. Observa cómo `get` sigue la cadena `outer` para resolver
+  identificadores externos.
+- El evaluador crea un entorno extendido para cada llamada en `applyFunction` (`src/evaluator.ts:225`). Cambia el valor inicial de
+  `saludo` y confirma que la clausura conserva el valor correcto dentro del procedimiento.
+- Ejecuta `bun test src/tests/engine.spec.ts` para ver cómo se combinan parseo y evaluación en escenarios completos.
+
+## Actividad 6 · Comprende y ajusta los built-ins
+
+- Revisa la implementación de `longitud` en `src/builtins.ts:4`. Nota cómo se validan aridad y tipos antes de devolver el
+  resultado.
+- En `src/evaluator.ts:275`, identifica dónde se conectan los built-ins cuando un identificador no está en el entorno actual.
+- Prueba a crear un nuevo built-in (por ejemplo, `mayusculas`) y ejecútalo en el REPL. Recuerda añadir también su test espejo en
+  `src/tests/evaluator.spec.ts`.
+
+## Checklist de autoevaluación
+
+- [ ] Puedo explicar qué hace `Lexer.nextToken` sin mirar el código.
+- [ ] Sé localizar la definición de un nodo AST a partir de su nombre.
+- [ ] Comprendo cómo `evaluateNode` delega en funciones auxiliares según el tipo de nodo.
+- [ ] Soy capaz de leer la traza de ejecución e identificar en qué paso cambia una variable.
+- [ ] Sé dónde registrar un nuevo built-in y cómo probarlo.
+
+## Próximos retos
+
+1. Añade un operador nuevo (por ejemplo, concatenación con `&`) y documenta el cambio replicando la ruta completa: lexer → parser
+   → evaluador → tests.
+2. Implementa la semántica de `mientras` siguiendo los TODOs existentes en `src/evaluator.ts` y crea ejemplos en el recetario.
+3. Escribe una clase corta para tu grupo de estudio usando esta guía como plan de sesiones.
+
+Con este recorrido habrás visto cómo cada módulo del repositorio se relaciona con la experiencia de programar en Codexivo. Usa la
+especificación del lenguaje (`docs/lenguaje.md`) y la descripción de arquitectura (`docs/arquitectura.md`) como referencias
+rápidas mientras sigues explorando.

--- a/docs/lenguaje.md
+++ b/docs/lenguaje.md
@@ -1,0 +1,154 @@
+# Especificación del lenguaje Codexivo
+
+Esta guía define Codexivo como si fuera un lenguaje de programación formal. Describe qué construcciones son válidas, cómo se
+interpreta cada una y qué mensajes de error expone el intérprete. Úsala como referencia definitiva mientras escribes código.
+
+## Filosofía general
+
+Codexivo está pensado para personas hispanohablantes que se inician en programación. Sus decisiones de diseño buscan:
+
+- **Claridad verbal**: se prefieren palabras clave en español sobre símbolos crípticos.
+- **Modelo mental cercano a JavaScript**: las expresiones se evalúan de izquierda a derecha y los procedimientos funcionan como
+  funciones regulares.
+- **Simplicidad en tipos**: actualmente se soportan números, cadenas, booleanos y el valor especial `nulo`.
+
+## Estructura de un programa
+
+Un programa es una secuencia de declaraciones separadas por punto y coma opcional (`;`). El intérprete ignora saltos de línea y
+espacios en blanco, de modo que puedes formatear tu código libremente. Internamente cada archivo se convierte en un `Program`
+con una lista de nodos del árbol de sintaxis abstracta (AST). 【F:src/ast.ts†L33-L61】
+
+## Palabras reservadas
+
+Las siguientes palabras tienen significado especial y no pueden utilizarse como identificadores ni nombres de parámetros:
+
+```
+hacer, hasta_que, pero_si, procedimiento, regresa, si, si_no, falso, variable,
+verdadero, mientras, no, o, para, y
+```
+
+Son detectadas tanto en el léxico como al validar identificadores. 【F:src/token.ts†L44-L75】【F:src/parser.ts†L560-L567】
+
+## Literales y operadores
+
+### Números
+
+- Se aceptan enteros y decimales escritos con punto (`10`, `0.5`, `.8`).
+- Los operadores aritméticos soportados son `+`, `-`, `*`, `/` y la negación prefija `-`. 【F:src/evaluator.ts†L330-L382】
+- El intérprete conserva la precisión de los decimales según lo provea JavaScript.
+
+### Booleanos
+
+- Las constantes `verdadero` y `falso` evalúan a valores lógicos.
+- Puedes combinarlos con los operadores de comparación (`==`, `!=`, `<`, `>`, `<=`, `>=`) y con las operaciones lógicas `y`,
+  `o` y la negación `!`. 【F:src/token.ts†L1-L43】【F:src/evaluator.ts†L382-L422】
+- Toda expresión tiene una "verdad" implícita: `0`, cadenas vacías y `nulo` se consideran falsy, el resto truthy. 【F:src/evaluator.ts†L443-L462】
+
+### Cadenas de texto
+
+- Se delimita con comillas simples o dobles (`"hola"`, `'mundo'`). 【F:src/lexer.ts†L58-L89】
+- Puede concatenarse con `+` y compararse con `==` / `!=`. 【F:src/evaluator.ts†L394-L421】
+
+### Agrupación y precedencia
+
+Usa paréntesis para agrupar expresiones y forzar la precedencia estándar (multiplicación y división antes que suma y resta). El
+parser emplea un sistema de precedencias inspirado en Pratt parsing. 【F:src/parser.ts†L40-L119】【F:src/parser.ts†L230-L246】
+
+## Declaraciones y expresiones
+
+### Variables
+
+Declara variables con la palabra clave `variable` seguida de un identificador y una expresión asignada:
+
+```codexivo
+variable edad = 16;
+variable mensaje = "Hola" + " mundo";
+```
+
+Cada declaración produce un nodo `LetStatement` y, al evaluarse, almacena el resultado en el entorno actual. 【F:src/parser.ts†L536-L568】【F:src/evaluator.ts†L120-L143】
+
+### Expresiones sueltas
+
+Cualquier expresión puede aparecer como sentencia; su valor se devuelve como resultado del programa si es la última en ejecutarse.
+Esto permite escribir scripts orientados a cálculo rápido en el REPL. 【F:src/parser.ts†L500-L533】【F:src/evaluator.ts†L57-L77】
+
+### Procedimientos (funciones)
+
+Los procedimientos encapsulan lógica reutilizable y admiten parámetros por nombre:
+
+```codexivo
+variable saludar = procedimiento(nombre) {
+  regresa "Hola " + nombre;
+};
+
+saludar("Uriel");
+```
+
+- Se definen con `procedimiento(<parametros>) { ... }`.
+- Pueden asignarse a variables o retornarse desde otros procedimientos.
+- Dentro del cuerpo es válido usar `regresa` para devolver un valor y terminar la ejecución. 【F:src/parser.ts†L448-L523】【F:src/evaluator.ts†L143-L215】
+
+### Llamadas a procedimientos
+
+Invoca un procedimiento escribiendo su nombre seguido de paréntesis con los argumentos separados por comas. Durante la ejecución
+se crea un entorno interno que vincula cada parámetro con el valor recibido; los argumentos faltantes se rellenan con `nulo`.
+【F:src/parser.ts†L124-L203】【F:src/evaluator.ts†L212-L320】
+
+### Sentencias condicionales
+
+Codexivo ofrece estructuras condicionales encadenadas:
+
+```codexivo
+si (edad >= 18) {
+  regresa "adulto";
+} pero_si (edad >= 13) {
+  regresa "adolescente";
+} si_no {
+  regresa "niño";
+}
+```
+
+- `si` evalúa la condición y ejecuta el bloque correspondiente.
+- `pero_si` agrega ramas evaluadas en cascada.
+- `si_no` actúa como rama por defecto.
+- Las condiciones usan las reglas de verdad descritas arriba. 【F:src/parser.ts†L324-L399】【F:src/evaluator.ts†L215-L248】
+
+### Bucles
+
+El analizador reconoce las formas `mientras`, `hacer { ... } hasta_que (...)` y `para (...)`. Sin embargo, la versión actual del
+evaluador solo ejecuta expresiones condicionales y funciones; los bucles están en fase de diseño. Aprovecha esta sintaxis para
+explorar el AST, pero espera futuras versiones para una semántica completa. 【F:src/parser.ts†L204-L343】【F:src/evaluator.ts†L33-L320】
+
+## Bibliotecas estándar
+
+Por ahora existe un conjunto reducido de funciones built-in. Cada llamada se valida en cuanto al número y tipo de argumentos.
+
+| Nombre     | Descripción                                   | Firma                  |
+|------------|-----------------------------------------------|------------------------|
+| `longitud` | Devuelve la cantidad de caracteres de una cadena. | `longitud(cadena)` |
+
+Internamente los built-ins viven en `src/builtins.ts` y se exponen automáticamente al resolver identificadores. 【F:src/builtins.ts†L1-L16】【F:src/evaluator.ts†L248-L320】
+
+## Manejo de errores
+
+Cuando se detecta un problema semántico, el evaluador genera objetos de error con mensajes en español que incluyen la ubicación
+(linea y columna). Entre los casos cubiertos están: uso de palabras reservadas, tipos incompatibles, identificadores desconocidos
+u operadores inválidos. 【F:src/errors.ts†L1-L200】【F:src/evaluator.ts†L248-L352】
+
+El parser también acumula errores sintácticos si encuentra tokens inesperados o identificadores prohibidos. Revísalos antes de
+ejecutar un programa. 【F:src/parser.ts†L86-L117】【F:src/parser.ts†L244-L285】
+
+## Valor de un programa
+
+El resultado de ejecutar un archivo es el valor de la última sentencia evaluada (o el valor retornado explícitamente). Si ninguna
+sentencia produce resultado, el programa devuelve `nulo`. Esto es útil para experimentar en el REPL y para escribir scripts que
+simplemente imprimen o retornan valores. 【F:src/evaluator.ts†L41-L83】
+
+## Próximos pasos
+
+- Completar la semántica de bucles y arreglos.
+- Ampliar la biblioteca estándar (entrada/salida, estructuras de datos).
+- Documentar futuras características en este mismo estándar.
+
+Mantén esta especificación a mano mientras practicas: cada ejemplo de código en el recetario hace referencia a los apartados
+anteriores para reforzar el aprendizaje progresivo.

--- a/docs/recetario.md
+++ b/docs/recetario.md
@@ -94,7 +94,11 @@ esNombreValido("Ana");
 
 Ejemplo de uso del builtin `longitud` junto con operadores de comparación y booleanos.
 
-> ℹ️ Los bucles (`mientras`, `hacer`/`hasta_que`, `para`) todavía no tienen semántica ejecutable en la versión actual del
-> intérprete. Mientras tanto, puedes simular repeticiones con recursión controlada como se muestra en el ejemplo 5.
+## ⚠️ Limitaciones actuales
+
+> **Importante:** Los bucles (`mientras`, `hacer`/`hasta_que`, `para`) todavía no tienen semántica ejecutable en la versión actual del intérprete. Por ahora, puedes simular repeticiones con recursión controlada como se muestra en el ejemplo 5.
+
+Esta limitación es temporal y será resuelta en futuras versiones del lenguaje.
+
 
 Experimenta combinando estos patrones y consulta la [especificación del lenguaje](./lenguaje.md) para profundizar en cada tema.

--- a/docs/recetario.md
+++ b/docs/recetario.md
@@ -1,0 +1,100 @@
+# Recetario de programas Codexivo
+
+Esta colección de programas ilustra patrones útiles del lenguaje. Cada ejemplo está listo para copiarse en el REPL o en un
+archivo `.codexivo`.
+
+## 1. Hola mundo personalizado
+
+```codexivo
+variable saludar = procedimiento(nombre) {
+  regresa "Hola " + nombre + "!";
+};
+
+saludar("Codexivo");
+```
+
+Demuestra cómo declarar un procedimiento, concatenar cadenas y retornar un valor.
+
+## 2. Clasificador por edades
+
+```codexivo
+variable clasificar = procedimiento(edad) {
+  si (edad >= 18) {
+    regresa "adulto";
+  } pero_si (edad >= 13) {
+    regresa "adolescente";
+  } si_no {
+    regresa "niño";
+  }
+};
+
+clasificar(16);
+```
+
+Ilustra el encadenamiento `si`/`pero_si`/`si_no` y el uso de operadores relacionales.
+
+## 3. Promedio simple
+
+```codexivo
+variable promedio = procedimiento(a, b, c) {
+  variable total = a + b + c;
+  regresa total / 3;
+};
+
+promedio(8, 7.5, 9);
+```
+
+Combina números enteros y decimales con operaciones aritméticas.
+
+## 4. Valor absoluto
+
+```codexivo
+variable valorAbsoluto = procedimiento(n) {
+  si (n < 0) {
+    regresa -n;
+  } si_no {
+    regresa n;
+  }
+};
+
+valorAbsoluto(-42);
+```
+
+Ejemplo de uso del operador prefijo `-` y del comportamiento truthy/falsy en condicionales.
+
+## 5. Contador recursivo
+
+```codexivo
+variable cuentaRegresiva = procedimiento(n) {
+  si (n == 0) {
+    regresa "¡Despegue!";
+  }
+
+  regresa cuentaRegresiva(n - 1);
+};
+
+cuentaRegresiva(3);
+```
+
+Muestra cómo las funciones en Codexivo soportan recursión gracias a que conservan su entorno de definición.
+
+## 6. Validación de longitud
+
+```codexivo
+variable esNombreValido = procedimiento(nombre) {
+  variable tamaño = longitud(nombre);
+  si (tamaño >= 3 y tamaño <= 15) {
+    regresa verdadero;
+  }
+  regresa falso;
+};
+
+esNombreValido("Ana");
+```
+
+Ejemplo de uso del builtin `longitud` junto con operadores de comparación y booleanos.
+
+> ℹ️ Los bucles (`mientras`, `hacer`/`hasta_que`, `para`) todavía no tienen semántica ejecutable en la versión actual del
+> intérprete. Mientras tanto, puedes simular repeticiones con recursión controlada como se muestra en el ejemplo 5.
+
+Experimenta combinando estos patrones y consulta la [especificación del lenguaje](./lenguaje.md) para profundizar en cada tema.

--- a/docs/repl.md
+++ b/docs/repl.md
@@ -1,0 +1,53 @@
+# Uso del REPL y flujo de trabajo
+
+El REPL (Read-Eval-Print-Loop) de Codexivo permite experimentar con el lenguaje en la terminal sin crear archivos. A medida que
+escribes expresiones, el intérprete las tokeniza, parsea y ejecuta en caliente.
+
+## Cómo iniciarlo
+
+1. Instala dependencias con `bun install`.
+2. Ejecuta `bun run repl` desde la raíz del proyecto.
+3. Verás el banner de bienvenida seguido de un prompt `>>`. 【F:src/cli.ts†L1-L20】
+
+También puedes invocar `bun run src/index.ts` para ejecutar programas completos con la misma infraestructura.
+
+## Interacción básica
+
+- Escribe declaraciones Codexivo y presiona Enter. El REPL guarda el historial en memoria (`scanned`) para que las variables
+  declaradas sigan disponibles en líneas posteriores.
+- Para salir escribe `salir();` y presiona Enter. 【F:src/repl.ts†L1-L48】
+- Si el parser detecta errores, estos se muestran y no se evalúa el programa parcial. 【F:src/repl.ts†L32-L47】
+
+### Ejemplo de sesión
+
+```
+>> variable saludo = procedimiento(nombre) { regresa "Hola " + nombre; };
+>> saludo("Codexivo");
+Hola Codexivo
+>> salir();
+Adios!
+```
+
+## Trazado y depuración
+
+El REPL se centra en la experiencia interactiva, pero puedes habilitar el modo trazado en scripts personalizados aprovechando el
+motor (`CodexivoEngine`) y el `RuntimeTracer`:
+
+```ts
+import { CodexivoEngine } from './src/engine';
+
+const engine = new CodexivoEngine();
+const { trace } = engine.run("variable x = 1;", { trace: true });
+console.log(trace?.events);
+```
+
+Cada evento incluye el nodo visitado, el entorno y los cambios detectados. Esto es ideal para entender paso a paso cómo se
+actualizan las variables mientras enseñas el lenguaje. 【F:src/engine.ts†L32-L83】【F:src/runtime/tracer.ts†L1-L173】
+
+## Consejos prácticos
+
+- Guarda tus experimentos pegando varias líneas seguidas; el REPL mantiene el estado acumulado.
+- Usa el comando del sistema `Ctrl+C` si necesitas abortar una ejecución que quedó esperando entrada.
+- Ejecuta `bun test` regularmente para asegurarte de que los cambios en el lenguaje no rompan la suite automatizada.
+
+Con estas herramientas podrás iterar rápidamente mientras aprendes la sintaxis o desarrollas nuevas capacidades para Codexivo.


### PR DESCRIPTION
## Summary
- add a documentation hub in `docs/` covering the Codexivo language specification
- explain the interpreter architecture and workflow for learners and contributors
- provide REPL guidance and a cookbook of example programs

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d6dbc487fc832b855fa9a4865d23ba